### PR TITLE
devportal v2- more configurable paths and naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # devportal-content
-User content for Ambassador Edge Stack Dev Portal
+User content for Ambassador Edge Stack Dev Portal.
+
+V2 is compatible with Edge Stack 1.13+.
+
+If using an earlier version, use v1 of the DevPortal content [here](https://github.com/datawire/devportal-content).
 
 ## How to customize
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ Templating allows you to customize how pages look, create variables to use in st
 
 ### Variables
 These variables are available in all template-able file types
-| Name                | Description                                                        | Values (example)            |
-| ------------------- | ------------------------------------------------------------------ | --------------------------- |
-| `.Ctx`              | The current type of page being served                              | "landing", "page", or "doc" |
-| `.Prefix`           | The url prefix of the current request                              | `/docs/`                    |
-| `.Pages`            | List of static pages in the `pages/` directory                     | `[Content Introduction]`    |
-| `.CurrentPage`      | The current page being accessed                                    | `Content`                   |
-| `.CurrentNamespace` | The namespace of the service for the current OpenAPI documentation | `default`                   |
-| `.CurrentService`   | The name of the service for the current OpenAPI documentation      | `quote`                     |
+| Name                  | Description                                                        | Values (example)            |
+| -------------------   | ------------------------------------------------------------------ | --------------------------- |
+| `.Ctx`                | The current type of page being served                              | "landing", "page", or "doc" |
+| `.Prefix`             | The url prefix of the current request                              | `/docs/`                    |
+| `.Pages`              | List of static pages in the `pages/` directory                     | `[Content Introduction]`    |
+| `.CurrentPage`        | The current page being accessed                                    | `Content`                   |
+| `.CurrentNamespace`   | The namespace of the service for the current OpenAPI documentation | `default`                   |
+| `.CurrentService`     | The name of the service for the current OpenAPI documentation      | `quote`                     |
+| `.CurrentServicePath` | Relative service path for currently displayed service              | `default/quote`             |

--- a/fragments/navigation.gohtml
+++ b/fragments/navigation.gohtml
@@ -1,6 +1,8 @@
 <nav class="o-page__nav c-nav">
   {{$haveApi := false}}
   {{$haveOther := false}}
+  {{$docBasePath := printf "%s%s" $.Prefix $.S.DocsBasePath }}
+  {{$pageBasePath := printf "%s%s" $.Prefix $.S.PageBasePath }}
   {{range $i, $element := .S.K8sStore.Slice }}
     {{if $element.Metadata.HasDoc}}
       {{$haveApi = true}}
@@ -19,8 +21,8 @@
             {{end}}
             {{if $element.Metadata.HasDoc}}
             <li>
-                <a class="{{$class}}" href="{{$.Prefix}}doc/{{$svc.Namespace}}/{{$svc.Name}}">
-                    {{$svc.Namespace}}.{{$svc.Name}}
+                <a class="{{$class}}" href="{{$docBasePath}}{{$element.Metadata.DevportalPath}}">
+                    {{ $element.Metadata.ServiceDisplayName }}
                 </a>
             </li>
             {{end}}
@@ -39,7 +41,7 @@
                 {{if eq $.CurrentPage $page}}
                     {{$class = "c-nav__selected"}}
                 {{end}}
-                <li><a class="{{$class}}" href="{{$.Prefix}}page/{{$page}}">{{$page}}</a></li>
+                <li><a class="{{$class}}" href="{{$pageBasePath}}{{$page}}">{{$page}}</a></li>
             {{end}}
         </ul>
     </div>

--- a/fragments/swagger.gohtml
+++ b/fragments/swagger.gohtml
@@ -7,7 +7,7 @@
 <span id="swagger-ui"></span>
 <script>
  const ui = SwaggerUIBundle({
-     url: "/openapi/services/{{.CurrentNamespace}}/{{.CurrentService}}/openapi.json",
+     url: "/openapi/services/{{.CurrentServicePath}}/openapi.json",
      dom_id: '#swagger-ui',
      presets: [
          SwaggerUIBundle.presets.apis,

--- a/landing.gomd
+++ b/landing.gomd
@@ -7,7 +7,7 @@
 
 ## Customizing the Portal
 
-This content is fully customizable for your specific needs. 
+This content is fully customizable for your specific needs.
 For details on customizing the portal, see https://www.getambassador.io/reference/dev-portal.
 
 ## Available Services
@@ -29,11 +29,12 @@ The following services are exposed through this Ambassador instance:
             <tr>
                 {{end}}
                 <td>
-                    <samp>{{$element.Service.Namespace}}.{{$element.Service.Name}}</samp>
+                    <samp>{{$element.Metadata.ServiceDisplayName}}</samp>
                 </td>
                 <td>
+                    {{$docBasePath := printf "%s%s" $.Prefix $.S.DocsBasePath }}
                     {{if $element.Metadata.HasDoc}}
-                    <a href="{{$.Prefix}}doc/{{$element.Service.Namespace}}/{{$element.Service.Name}}"><code>API Documentation</code></a>
+                    <a href="{{$docBasePath}}{{$element.Metadata.DevportalPath}}"><code>API Documentation</code></a>
                     {{else}}
                     <code><span style="color:red">No API Documentation</span></code>
                     {{end}}


### PR DESCRIPTION
The compliment to https://github.com/datawire/apro/pull/2493

I decided to just fork into a V2 repo instead of having a bunch of conditional logic in the previous devportal to be backwards and forward compat.

From aes 1.13 on, the default devportal url will point here instead of the old repo.